### PR TITLE
Deprecated command 'compile' removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,13 @@ SOURCES=src/update.cr
 EXECUTABLE=update
 INSTALL_DIR=/usr/local/bin
 
-all: spec compile
+all: spec build
 
 spec:
 	$(CRYSTAL) spec
 
-build: compile
-compile:
-	$(CRYSTAL) compile $(CRYSTAL_FLAGS) $(SOURCES) -o $(EXECUTABLE)
+build:
+	$(CRYSTAL) build $(CRYSTAL_FLAGS) $(SOURCES) -o $(EXECUTABLE)
 
 install:
 	cp $(EXECUTABLE) $(INSTALL_DIR)


### PR DESCRIPTION
To avoid this:

```
~/Projects/crystal/update (master|✔) $ make
crystal spec
crystal compile --release src/update.cr -o update
Deprecation: The compile command was renamed to build and will be removed in a future version.
```
