### PR TITLE
YAML with Providers loaded in compile time (closing #5)

### DIFF
--- a/src/update.cr
+++ b/src/update.cr
@@ -1,6 +1,6 @@
 require "./update/provider"
 
-yaml = File.read File.join(__DIR__, "providers.yml")
+yaml = {{ `cat #{__DIR__}/providers.yml`.stringify }}
 
 providers = Array(Update::Provider).from_yaml yaml
 


### PR DESCRIPTION
Platform-dependent solution with `cat` and `/` in file path (from [here](https://github.com/crystal-lang/crystal/issues/1649))

Normal solution [not realized yet](https://github.com/crystal-lang/crystal/issues/2751) in Crystal :(
